### PR TITLE
DUB Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "gl3n",
+	"description": "OpenGL Maths for D (not glm for D but better).",
+	"homepage": "http://dav1dde.github.com/gl3n/",
+	"copyright": "Copyright © 2011, David Herberth",
+    "license": "MIT",
+    "targetType": "staticLibrary",
+    "targetName": "gl3n",
+    "sourcePaths": ["gl3n"],
+    "dflags": ["-O", "-w", "-release"],
+	"authors": [
+		"David Herberth"
+	],
+	"dependencies": {
+	}
+}


### PR DESCRIPTION
Issue #12. Adds support for DUB build-system/package-manager. Tested on ArchLinux 64bit with no issues.
