### PR TITLE
Appease dub warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "targetType": "staticLibrary",
     "targetName": "gl3n",
     "sourcePaths": ["gl3n"],
-    "dflags": ["-O", "-w", "-release"],
     "authors": [
         "David Herberth"
     ],


### PR DESCRIPTION
Latest version of dub issues warnings about all three of the specified flags:

```
## Warning for package gl3n ##

The following compiler flags have been specified in the package description
file. They are handled by DUB and direct use in packages is discouraged.
Alternatively, you can set the DFLAGS environment variable to pass custom flags
to the compiler, or use one of the suggestions below:

-O: Call dub with --build=release
-w: Use "buildRequirements" to control warning behavior
-release: Call dub with --build=release
```
