### PR TITLE
add workaround

### DIFF
--- a/gl3n/linalg.d
+++ b/gl3n/linalg.d
@@ -2279,9 +2279,9 @@ struct Quaternion(type) {
                quat.identity.rotate_axis(PI, vec3(1.0f, 1.0f, 1.0f)).quaternion);
         
         quat q1 = quat.euler_rotation(PI, PI, PI);
-        assert((q1.x > -2.71052e-20) && (q1.x < -2.71050e-20));
-        assert((q1.y > -2.71052e-20) && (q1.y < -2.71050e-20));
-        assert((q1.z > 2.71050e-20) && (q1.z < 2.71052e-20));
+        assert((q1.x > -1e-16) && (q1.x < 1e-16));
+        assert((q1.y > -1e-16) && (q1.y < 1e-16));
+        assert((q1.z > -1e-16) && (q1.z < 1e-16));
         assert(q1.w == -1.0f);
         assert(quat.euler_rotation(PI, PI, PI).quaternion == quat.identity.rotate_euler(PI, PI, PI).quaternion);
     }


### PR DESCRIPTION
Yesterday a gl3n user on IRC found a DMD regression:
http://d.puremagic.com/issues/show_bug.cgi?id=11238

It affected Matrix.invert(); (wrong results), starting from DMD 2.063.

A simple program to expose the bug:

```
import std.stdio;
import gl3n.linalg;

void main()
{
    mat4 M = mat4(2, 0, 0, 0, 
                  0, 1, 0, 0,
                  0, 0, 1, 0,
                  0, 0, 0, 1);

    writefln("M = %s", M);
    M.invert();
    writefln("M = %s", M);
    M.invert();
    writefln("M = %s", M);
}
```

This pull request is one way to workaround it. 
(damn, a newline in the diff)
