### PR TITLE
get rid of dub warning message, and support gl3n as a reps when...

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "targetType": "staticLibrary",
     "targetName": "gl3n",
     "sourcePaths": ["gl3n"],
+    "importPaths": ["."],
     "authors": [
         "David Herberth"
     ],


### PR DESCRIPTION
using --rdmd flag (or the import flag will not be pushed into rdmd command line)
