### PR TITLE
Add "importPaths" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "targetType": "staticLibrary",
     "targetName": "gl3n",
     "sourcePaths": ["gl3n"],
+    "importPaths": ["."],
     "authors": [
         "David Herberth"
     ],


### PR DESCRIPTION
Building gl3n separately using "dub generate visuald" currently fails because DMD cannot find the import files. This entry should fix it - see also https://github.com/rejectedsoftware/dub/issues/136
