### PR TITLE
Bug fix, so Vector types can be used as a key in an AA

### DIFF
--- a/gl3n/linalg.d
+++ b/gl3n/linalg.d
@@ -63,6 +63,11 @@ struct Vector(type, int dimension_) {
     }
     alias as_string toString; /// ditto
 
+    // Returns the hash. Requires TypeInfo_Struct to get the hash.
+    size_t toHash() const nothrow @safe {
+            return typeid(typeof(this)).getHash(&this);
+    }
+    
     @safe pure nothrow:
     ///
     private @property ref inout(vt) get_(char coord)() inout {


### PR DESCRIPTION
I'm not sure this is the best way to go about getting a hash.
But atleast this will allow vectors to be used as a key.
