### PR TITLE
fix dmd2068-b1 warning

### DIFF
--- a/gl3n/linalg.d
+++ b/gl3n/linalg.d
@@ -422,7 +422,7 @@ struct Vector(type, int dimension_) {
 
         if(len != 0) {
             foreach(index; TupleRange!(0, dimension)) {
-                vector[index] /= len;
+                vector[index] = cast(type)(vector[index]/len);
             }
         }
     }


### PR DESCRIPTION
warning was:
```
gl3n/linalg.d(425): Warning: int /= real is performing truncating conversion
```