### PR TITLE
Fixed deprecated reference; std.typecons.TypeTuple -> std.meta.AliasSeq

### DIFF
--- a/gl3n/util.d
+++ b/gl3n/util.d
@@ -11,8 +11,17 @@ private {
     import gl3n.linalg : Vector, Matrix, Quaternion;
     import gl3n.plane : PlaneT;
 
-    import std.meta : AliasSeq;
-    alias TypeTuple = AliasSeq;
+    static import std.compiler;
+
+    static if (std.compiler.version_major > 2 ||
+               std.compiler.version_minor > 68)
+    {
+        import std.meta : AliasSeq;
+        alias TypeTuple = AliasSeq;
+    }
+    else {
+        import std.typetuple : TypeTuple;
+    }
 }
 
 private void is_vector_impl(T, int d)(Vector!(T, d) vec) {}

--- a/gl3n/util.d
+++ b/gl3n/util.d
@@ -11,7 +11,8 @@ private {
     import gl3n.linalg : Vector, Matrix, Quaternion;
     import gl3n.plane : PlaneT;
 
-    import std.typecons : TypeTuple;
+    import std.meta : AliasSeq;
+    alias TypeTuple = AliasSeq;
 }
 
 private void is_vector_impl(T, int d)(Vector!(T, d) vec) {}
@@ -48,7 +49,7 @@ unittest {
     // or a linker error depending where gl3n.util gets imported
     import gl3n.linalg;
     import gl3n.plane;
-    
+
     assert(is_vector!vec2);
     assert(is_vector!vec3);
     assert(is_vector!vec3d);
@@ -56,14 +57,14 @@ unittest {
     assert(!is_vector!int);
     assert(!is_vector!mat34);
     assert(!is_vector!quat);
-    
+
     assert(is_matrix!mat2);
     assert(is_matrix!mat34);
     assert(is_matrix!mat4);
     assert(!is_matrix!float);
     assert(!is_matrix!vec3);
     assert(!is_matrix!quat);
-    
+
     assert(is_quaternion!quat);
     assert(!is_quaternion!vec2);
     assert(!is_quaternion!vec4i);


### PR DESCRIPTION
Hello! I'm using the head version of the dmd compiler and this deprecated symbol has been removed from the standard library.

This fix uses the new symbol as a private alias to the old so the module has minimal changes to it.

Emacs also happened to fix some trailing whitespace on the way..