### PR TITLE
Convert git:// github submodule URLs to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bootDoc"]
 	path = bootDoc
-	url = git://github.com/JakobOvrum/bootDoc.git
+	url = https://github.com/JakobOvrum/bootDoc.git


### PR DESCRIPTION
Since github disabled the git:// protocol, cloning the submodule no longer works. This commit fixes that.